### PR TITLE
Rewrite rule for factoring out common cause failures

### DIFF
--- a/dftlib/transformer/rewrite_rules.py
+++ b/dftlib/transformer/rewrite_rules.py
@@ -25,6 +25,7 @@ class RewriteRules(Enum):
     TRIM = 32
     REMOVE_DEPENDENCIES_TLE = 33
     REMOVE_DUPLICATES = 34
+    FACTOR_COMMON_CAUSE = 35
     MERGE_IDENTICAL_GATES = 2
     REMOVE_SINGLE_SUCCESSOR = 3
     ADD_SINGLE_OR = 4
@@ -47,6 +48,8 @@ class RewriteRules(Enum):
             return try_remove_dependencies
         elif rule == RewriteRules.REMOVE_DUPLICATES:
             return try_remove_duplicates
+        elif rule == RewriteRules.FACTOR_COMMON_CAUSE:
+            return try_factor_common_cause
         elif rule == RewriteRules.MERGE_IDENTICAL_GATES:
             # This method requires two gates as input
             return try_merge_identical_gates
@@ -269,6 +272,74 @@ def try_remove_duplicates(dft, gate):
     for element in duplicates:
         gate.remove_child(element)
 
+    return True
+
+
+def try_factor_common_cause(dft, gate):
+    """
+    Try to factor out a common cause failure.
+    A structure (A || B) && (B || C) with common cause B can be rewritten to B || (A && C).
+    :param dft: DFT
+    :param gate: Gate.
+    :return: True iff common cause factoring was successful.
+    """
+    # Check if rule is applicable
+    if not isinstance(gate, dft_gates.DftAnd):
+        return False
+    if len(gate.children()) <= 1:
+        return False
+
+    # Search for common cause candidates
+    common_causes = None
+    for or_gate in gate.children():
+        if not isinstance(or_gate, dft_gates.DftOr):
+            return False
+        if len(or_gate.parents()) > 1:
+            # Only AND-gate should be the parent
+            return False
+
+        children = set([c.element_id for c in or_gate.children()])
+        if common_causes is None:
+            common_causes = children
+        else:
+            # Intersection to only keep common cause failures
+            common_causes &= children
+
+    if len(common_causes) == 0:
+        # No common cause failures found
+        return False
+
+    common_causes = [dft.get_element(c) for c in common_causes]
+
+    # Remove common causes from OR-gates
+    for or_gate in gate.children():
+        for common_cause in common_causes:
+            or_gate.remove_child(common_cause)
+
+    # Create new AND-gate over remaining Or-gates
+    # This gate represents the independent failures
+    position = (gate.position[0] + 100, gate.position[1] + 150)
+    independent_gate = dft_gates.DftAnd(dft.next_id(), gate.name + "_IndepFailures", gate.children(), position)
+    dft.add(independent_gate)
+
+    # Set element for common cause failures
+    # If there are multiple ones, introduce a new gate
+    if len(common_causes) > 1:
+        position = (gate.position[0] - 100, gate.position[1] + 150)
+        common_cause = dft_gates.DftOr(dft.next_id(), gate.name + "_CommonCauseFailures", common_causes, position)
+        dft.add(common_cause)
+    else:
+        common_cause = common_causes[0]
+
+    # Create new OR-gate as combination of common causes and independent failures
+    position = (gate.position[0], gate.position[1] + 50)
+    or_gate = dft_gates.DftOr(dft.next_id(), gate.name + "_2", [common_cause, independent_gate], position)
+    # Add new gate as single child of existing gate
+    # This will be simplified later on with rule REMOVE_SINGLE_SUCCESSOR
+    dft.add(or_gate)
+    while len(gate.children()) > 0:
+        gate.remove_child(gate.children()[0])
+    gate.add_child(or_gate)
     return True
 
 

--- a/dftlib/transformer/rewrite_rules.py
+++ b/dftlib/transformer/rewrite_rules.py
@@ -102,7 +102,7 @@ def try_merge_bes_in_or(dft, or_gate):
     """
     Try to merge BEs under an OR-gate into one BE.
     :param dft: DFT.
-    :param or_gate: OR gate.
+    :param or_gate: OR-gate.
     :return: True iff merge was successful.
     """
     # Check if rule is applicable
@@ -206,7 +206,7 @@ def try_merge_bes_in_or(dft, or_gate):
 def has_immediate_failure(dft, gate):
     """
     Checks whether a failure of the gate leads to an immediate failure of the top level element.
-    In other words, all parents are OR gates.
+    In other words, all parents are OR-gates.
     :param dft: DFT.
     :param gate: Gate.
     :return: True iff failure leads to system failure.
@@ -249,8 +249,8 @@ def try_remove_duplicates(dft, gate):
     :param gate: Gate.
     :return: True iff removal was successful.
     """
-
-    if gate.is_be():
+    # Duplicates must be kept if order of children is important
+    if not (isinstance(gate, dft_gates.DftAnd) or isinstance(gate, dft_gates.DftOr) or isinstance(gate, dft_gates.DftVotingGate)):
         return False
 
     # Check if duplicates exist
@@ -263,10 +263,6 @@ def try_remove_duplicates(dft, gate):
             if idi == idj:
                 duplicates.append(element)
     if not duplicates:
-        return False
-
-    # Duplicates must be kept if order of children is important
-    if not (isinstance(gate, dft_gates.DftAnd) or isinstance(gate, dft_gates.DftOr) or isinstance(gate, dft_gates.DftVotingGate)):
         return False
 
     # Remove duplicate
@@ -454,7 +450,7 @@ def add_or_as_predecessor(dft, element, name=None):
     :param dft: DFT.
     :param element: Element which gets an OR as predecessor.
     :param name: Name of new OR-gate.
-    :return: The new OR gate or None.
+    :return: The new OR-gate or None.
     """
     if name is None:
         name = "OR_{}".format(dft.next_id())
@@ -498,8 +494,8 @@ def check_for_cycle(dft, element, current):
     The cycle check excludes dependencies and restrictors.
     :param dft: DFT.
     :param element: Element to search for.
-    :param ceurrent Current element.
-    :return: True iff the predecessor closure of current contains eleement.
+    :param current: Current element.
+    :return: True iff the predecessor closure of current contains element.
     """
     if current.element_id == element.element_id:
         return True

--- a/dftlib/transformer/simplifier.py
+++ b/dftlib/transformer/simplifier.py
@@ -60,6 +60,7 @@ def simplify_dft_all_rules(dft):
         RewriteRules.TRIM,
         RewriteRules.REMOVE_DEPENDENCIES_TLE,
         RewriteRules.REMOVE_DUPLICATES,
+        RewriteRules.FACTOR_COMMON_CAUSE,
         RewriteRules.MERGE_IDENTICAL_GATES,
         RewriteRules.REMOVE_SINGLE_SUCCESSOR,
         # RewriteRules.ADD_SINGLE_OR, # Could lead to infinite loop by adding new gates
@@ -111,6 +112,8 @@ def simplify_dft_rules(dft, rules):
             logging.debug("Removed dependency: {}".format(element))
         elif rule == RewriteRules.REMOVE_DUPLICATES:
             logging.debug("Removed duplicates in gate {}".format(element))
+        elif rule == RewriteRules.FACTOR_COMMON_CAUSE:
+            logging.debug("Factored out common cause in gate {}".format(element))
         elif rule == RewriteRules.MERGE_IDENTICAL_GATES:
             logging.debug("Merged gate {}".format(element))
         elif rule == RewriteRules.REMOVE_SINGLE_SUCCESSOR:

--- a/dftlib/transformer/simplifier.py
+++ b/dftlib/transformer/simplifier.py
@@ -110,9 +110,9 @@ def simplify_dft_rules(dft, rules):
         elif rule == RewriteRules.REMOVE_DEPENDENCIES_TLE:
             logging.debug("Removed dependency: {}".format(element))
         elif rule == RewriteRules.REMOVE_DUPLICATES:
-            logging.debug("Removed duplicates in gate".format(element))
+            logging.debug("Removed duplicates in gate {}".format(element))
         elif rule == RewriteRules.MERGE_IDENTICAL_GATES:
-            logging.debug("Merged gate".format(element))
+            logging.debug("Merged gate {}".format(element))
         elif rule == RewriteRules.REMOVE_SINGLE_SUCCESSOR:
             logging.debug("Removed gate with single successor: {}".format(element))
         elif rule == RewriteRules.ADD_SINGLE_OR:

--- a/examples/simplify/rule35_test.json
+++ b/examples/simplify/rule35_test.json
@@ -1,0 +1,291 @@
+{
+    "toplevel": 0,
+    "parameters": {},
+    "nodes": [
+        {
+            "data": {
+                "id": "0",
+                "name": "T",
+                "type": "or",
+                "repairable": false,
+                "children": [
+                    "1",
+                    "11"
+                ],
+                "label": "T"
+            },
+            "position": {
+                "x": 287.4618615170728,
+                "y": 23.363138482927233
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "or toplevel"
+        },
+        {
+            "data": {
+                "id": "1",
+                "name": "K",
+                "type": "and",
+                "repairable": false,
+                "children": [
+                    "2",
+                    "3",
+                    "4"
+                ],
+                "label": "K"
+            },
+            "position": {
+                "x": 181.43069564564536,
+                "y": 170.20290660104547
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "and"
+        },
+        {
+            "data": {
+                "id": "2",
+                "name": "L",
+                "type": "or",
+                "repairable": false,
+                "children": [
+                    "6",
+                    "7",
+                    "5"
+                ],
+                "label": "L"
+            },
+            "position": {
+                "x": 45.25,
+                "y": 311.625
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "or"
+        },
+        {
+            "data": {
+                "id": "3",
+                "name": "M",
+                "type": "or",
+                "repairable": false,
+                "children": [
+                    "7",
+                    "5",
+                    "10"
+                ],
+                "label": "M"
+            },
+            "position": {
+                "x": 188.25,
+                "y": 311.625
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "or"
+        },
+        {
+            "data": {
+                "id": "4",
+                "name": "N",
+                "type": "or",
+                "repairable": false,
+                "children": [
+                    "10",
+                    "5"
+                ],
+                "label": "N"
+            },
+            "position": {
+                "x": 310,
+                "y": 311.625
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "or"
+        },
+        {
+            "data": {
+                "id": "5",
+                "name": "C",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 3,
+                "repair": 0,
+                "dorm": 0,
+                "label": "C (λ: 3)"
+            },
+            "position": {
+                "x": 229,
+                "y": 446.2750000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        },
+        {
+            "data": {
+                "id": "6",
+                "name": "A",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 1,
+                "repair": 0,
+                "dorm": 0,
+                "label": "A (λ: 1)"
+            },
+            "position": {
+                "x": 25.5,
+                "y": 446.2750000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        },
+        {
+            "data": {
+                "id": "7",
+                "name": "P",
+                "type": "pand",
+                "repairable": false,
+                "children": [
+                    "8",
+                    "9"
+                ],
+                "label": "P"
+            },
+            "position": {
+                "x": 127,
+                "y": 446.2750000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "pand"
+        },
+        {
+            "data": {
+                "id": "8",
+                "name": "B",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 1,
+                "repair": 0,
+                "dorm": 0,
+                "label": "B (λ: 1)"
+            },
+            "position": {
+                "x": 86,
+                "y": 568.6000000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        },
+        {
+            "data": {
+                "id": "9",
+                "name": "D",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 2,
+                "repair": 0,
+                "dorm": 0,
+                "label": "D (λ: 2)"
+            },
+            "position": {
+                "x": 188,
+                "y": 568.6000000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        },
+        {
+            "data": {
+                "id": "10",
+                "name": "E",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 4,
+                "repair": 0,
+                "dorm": 0,
+                "label": "E (λ: 4)"
+            },
+            "position": {
+                "x": 340.75,
+                "y": 446.2750000000001
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        },
+        {
+            "data": {
+                "id": "11",
+                "name": "F",
+                "type": "be_exp",
+                "repairable": false,
+                "rate": 1,
+                "repair": 0,
+                "dorm": 0,
+                "label": "F (λ: 1)"
+            },
+            "position": {
+                "x": 388.0753526693366,
+                "y": 167.49406924146362
+            },
+            "group": "nodes",
+            "removed": false,
+            "selected": false,
+            "selectable": true,
+            "locked": false,
+            "grabbable": true,
+            "classes": "be_exp"
+        }
+    ]
+}

--- a/tests/transformer/test_rewrite_rules.py
+++ b/tests/transformer/test_rewrite_rules.py
@@ -172,6 +172,24 @@ def test_rewrite_all_rule28():
     assert no_elements == 4
 
 
+def test_rewrite_all_rule35():
+    file = get_example_path("simplify", "rule35_test.json")
+    dft = dftlib.io.parser.parse_dft_json_file(file)
+    no_be, no_static, no_dynamic, no_elements = dft.statistics()
+    assert no_be == 6
+    assert no_static == 5
+    assert no_dynamic == 1
+    assert no_elements == 12
+
+    changed = simplifier.simplify_dft_all_rules(dft)
+    assert changed
+    no_be, no_static, no_dynamic, no_elements = dft.statistics()
+    assert no_be == 5
+    assert no_static == 3
+    assert no_dynamic == 1
+    assert no_elements == 9
+
+
 def test_rewrite_all_fdep_cycle():
     file = get_example_path("simplify", "fdep_cycle.json")
     dft = dftlib.io.parser.parse_dft_json_file(file)


### PR DESCRIPTION
The rewrite rule factors out common cause failures by applying the distributive law:
`(A || B) && (B || C)` has a common cause failure `B` and can be rewritten to `B || (A && C)`.

An example is the following DFT:
![original](https://github.com/user-attachments/assets/06101a4e-f1ec-43ca-bb36-9484e473eda4)

Applying the rewrite rule factors out the common cause failure `C`:
![rewrite](https://github.com/user-attachments/assets/79ca1d62-3c83-4ff6-b73b-6e14223782b1)

Further simplification yields:
![simplified](https://github.com/user-attachments/assets/b4753550-8b6e-4d42-acba-ac3c2501fac4)